### PR TITLE
Add default value for destination id in queue-detail query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 	- uwsgi active-user count
 	- exports PGAPPNAME setting the application name for postgres connections. This becomes visible in pg_stat_activity.
 	- mutate set_quota_for_oidc_user, by [@gmauro](https://github.com/gmauro).
+	- iquery support for queue-detail query
 
 # 19
 

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -428,7 +428,7 @@ query_queue-detail() { ##? [--all] [--seconds]: Detailed overview of running and
 	EOF
 
 	fields="count=9"
-	tags="state=0;id=1;extid=2;tool_id=3;username=4;time_since_creation=5;handler=6;job_runner_name=7;destination_id=8"
+	tags="state=0;id=1;extid=2;tool_id=3;username=4;time_since_creation=5;handler=6;job_runner_name=7"
 
 	d=""
 	nonpretty="("

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -428,7 +428,7 @@ query_queue-detail() { ##? [--all] [--seconds]: Detailed overview of running and
 	EOF
 
 	fields="count=9"
-	tags="state=0;id=1;extid=2;tool_id=3;username=4;time_since_creation=5;handler=6;job_runner_name=7"
+	tags="state=0;id=1;extid=2;tool_id=3;username=4;time_since_creation=5;handler=6;job_runner_name=7;destination_id=8"
 
 	d=""
 	nonpretty="("
@@ -452,7 +452,7 @@ query_queue-detail() { ##? [--all] [--seconds]: Detailed overview of running and
 			$nonpretty now() AT TIME ZONE 'UTC' - job.create_time) as time_since_creation,
 			job.handler,
 			job.job_runner_name,
-			job.destination_id,
+			COALESCE(job.destination_id, 'none') as destination_id,
 			1 as count
 		FROM job
 		FULL OUTER JOIN galaxy_user ON job.user_id = galaxy_user.id


### PR DESCRIPTION
The destination tag does not always seem to be available which causes problems when attempting to parse the results to influx.