### PR TITLE
Small change to `pulsar-gb-transferred`

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -3693,7 +3693,7 @@ query_pulsar-gb-transferred()  { ##? [--bymonth] [--byrunner] [--human]: Counts 
 						job.id DESC
 				)
 		SELECT
-			$csvcols ${pg_size_pretty_a}sum(sent.size)${pg_size_pretty_b} AS sent, ${pg_size_pretty_a}sum(recv.size)${pg_size_pretty_b} AS recv, count(sent.size) as job_count
+			$csvcols ${pg_size_pretty_a}sum(sent.size)${pg_size_pretty_b} AS sent, ${pg_size_pretty_a}sum(recv.size)${pg_size_pretty_b} AS recv, count(sent.size) as sent_count, count(recv.size) as recv_count
 		FROM
 			sent FULL JOIN recv ON sent.job = recv.job
 		$groupby


### PR DESCRIPTION
The name of the `job_count` column is a bit misleading, as it lists the number of sent datasets, not jobs. I renamed it to `sent_count` and also added a `recv_count` column.