### PR TITLE
Add a function for Galaxy group report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 	- mutate fail-misbehaving-gxits: Works aroud a gxit issue.
 	- galaxy prune-gxit-routes: Prunes dead routes
 	- mutate force-publish-history: Workaround for Galaxy bug #13001
+	- report group-info, by [@pavanvidem](https://github.com/pavanvidem)
 
 # 19
 

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -2817,7 +2817,7 @@ query_pg-column-size() { ##? <table>: Estimate the size of columns in a table
 		SELECT
 			$csvsel
 		FROM
-			x;
+			x
 	EOF
 
 }

--- a/parts/26-report.sh
+++ b/parts/26-report.sh
@@ -7,13 +7,11 @@ align_cols() {
 	cat | sed 's/\t/ | /g'
 }
 
-
-
 report_group-info(){ ## <group_id|groupname>: Quick overview of a Galaxy group in your system
 	handle_help "$@" <<-EOF
 		This command lets you quickly find out information about a Galaxy group. The output is formatted as markdown by default.
 		Consider [mdless](https://github.com/ttscoff/mdless) for easier reading in the terminal!
-		    $ gxadmin report group-info 
+		    $ gxadmin report group-info Backofen
 			# Galaxy Group 18
 				  Property | Value
 			-------------- | -----
@@ -31,7 +29,7 @@ report_group-info(){ ## <group_id|groupname>: Quick overview of a Galaxy group i
 			---- | ---- | ---- | ---- | --- | ---- | ---- | ----
 			bgruening | bgruening@gmail.com | 25 | t | 265 GB | 1421 | 1.14
 			helena-rasche | hxr@informatik.uni-freiburg.de | 122 | t | 37 GB | 113 | 2.91
-			videmp | videmp@hxr@informatik.uni-freiburg.de | 46 | t | 1383 MB | 96 | 0.02
+			videmp | videmp@informatik.uni-freiburg.de | 46 | t | 1383 MB | 96 | 0.02
 	EOF
 
 	# Metada

--- a/parts/26-report.sh
+++ b/parts/26-report.sh
@@ -13,7 +13,7 @@ report_group-info(){ ## <group_id|groupname>: Quick overview of a Galaxy group i
 		Consider [mdless](https://github.com/ttscoff/mdless) for easier reading in the terminal!
 		    $ gxadmin report group-info Backofen
 			# Galaxy Group 18
-				  Property | Value
+			      Property | Value
 			-------------- | -----
 			            ID | Backofen (id=1)
 			       Created | 2013-02-25 15:58:10.691672+01


### PR DESCRIPTION
The following is an example of usage. It takes either a Galaxy group id or group name.
```
    $ gxadmin report group-info Backofen
	# Galaxy Group 18
	      Property | Value
	-------------- | -----
	            ID | Backofen (id=1)
	       Created | 2013-02-25 15:58:10.691672+01
	    Properties | deleted=f
	    Group size | 8
	Number of jobs | 1630
	    Disk usage | 304 GB
	Data generated | 6894 GB
	     CPU years | 4.07

	## Member stats
	Username | Email | User ID | Active | Disk Usage | Number of jobs | CPU years
	---- | ---- | ---- | ---- | --- | ---- | ---- | ----
	bgruening | bgruening@gmail.com | 25 | t | 265 GB | 1421 | 1.14
	helena-rasche | hxr@informatik.uni-freiburg.de | 122 | t | 37 GB | 113 | 2.91
	videmp | videmp@informatik.uni-freiburg.de | 46 | t | 1383 MB | 96 | 0.02
```
