### PR TITLE
Bug fix: group-reports

### DIFF
--- a/parts/26-report.sh
+++ b/parts/26-report.sh
@@ -86,44 +86,42 @@ report_group-info(){ ## <group_id|groupname>: Quick overview of a Galaxy group i
 	# Group total CPU years
 	read -r -d '' qstr <<-EOF
 		SELECT
-			round(sum((a.metric_value * b.metric_value) / 3600 / 24 / 365), 2)
+			GREATEST(round(sum((a.metric_value * b.metric_value) / 3600 / 24 / 365), 2), 0.00)
 		FROM
-			job_metric_numeric a, job_metric_numeric b, job
-			FULL OUTER JOIN galaxy_user ON job.user_id = galaxy_user.id
-			INNER JOIN user_group_association ug ON ug.user_id=galaxy_user.id
+			job j FULL OUTER JOIN galaxy_user u ON j.user_id = u.id INNER JOIN user_group_association ug ON u.id=ug.user_id LEFT JOIN job_metric_numeric a ON a.job_id=j.id LEFT JOIN job_metric_numeric b ON a.job_id=b.job_id
 		WHERE
-			b.job_id = a.job_id AND a.job_id = job.id AND a.metric_name = 'runtime_seconds' AND b.metric_name = 'galaxy_slots' AND ug.group_id=$group_id
+			(a.metric_name = 'runtime_seconds' OR a.metric_value is NULL) AND (b.metric_name = 'galaxy_slots' OR b.metric_value is NULL) AND group_id=$group_id
 	EOF
 	g_total_cup_years=$(query_tsv "$qstr")
 
 	# Group members stats
 	read -r -d '' qstr <<-EOF
 		SELECT
-			u.username, u.email, u.id, u.active, pg_size_pretty(u.disk_usage), count(j.*), round(sum((a.metric_value * b.metric_value) / 3600 / 24 / 365), 2)
+			u.username, u.email, u.id, u.active, pg_size_pretty(u.disk_usage), count(j.*), GREATEST(round(sum((a.metric_value * b.metric_value) / 3600 / 24 / 365), 2), 0.00)
 		FROM
-			 job_metric_numeric a, job_metric_numeric b, job j FULL OUTER JOIN galaxy_user u ON j.user_id = u.id INNER JOIN user_group_association ug ON u.id=ug.user_id 
+			job j FULL OUTER JOIN galaxy_user u ON j.user_id = u.id INNER JOIN user_group_association ug ON u.id=ug.user_id LEFT JOIN job_metric_numeric a ON a.job_id=j.id LEFT JOIN job_metric_numeric b ON a.job_id=b.job_id
 		WHERE
-			u.id=j.user_id AND j.id=a.job_id AND a.metric_name = 'runtime_seconds' AND b.job_id = a.job_id AND a.job_id = j.id AND a.metric_name = 'runtime_seconds' AND b.metric_name = 'galaxy_slots' AND group_id=$group_id
+			(a.metric_name = 'runtime_seconds' OR a.metric_value is NULL) AND (b.metric_name = 'galaxy_slots' OR b.metric_value is NULL) AND group_id=$group_id
 		GROUP BY
 			u.id
 		ORDER BY
 			u.username
 	EOF
 	member_stats=$(query_tsv "$qstr")
-	member_stats_w_header=$(printf "Username\tEmail\tUser ID\tActive\tDisk Usage\tNumber of jobs\tCPU years\n----\t----\t----\t----\t---\t----\t----\t----\n%s" "$member_stats" | align_cols)
+	member_stats_w_header=$(printf "Username\tEmail\tUser ID\tActive\tDisk Usage\tNumber of jobs\tCPU years\n----\t----\t----\t----\t---\t----\t----\n%s" "$member_stats" | align_cols)
 
 	read -r -d '' template <<EOF
 # Galaxy Group $group_id
-       Property | Value
---------------- | -----
-             ID | %s (id=%s)
-        Created | %s %s
-     Properties | deleted=%s
-     Group size | %s
- Number of jobs | %s
-     Disk usage | %s %s
- Data generated | %s %s
-      CPU years | %s
+           Property | Value
+           -------- | ----
+                 ID | %s (id=%s)
+            Created | %s %s
+         Properties | deleted=%s
+         Group size | %s
+     Number of jobs | %s
+         Disk usage | %s %s
+     Data generated | %s %s
+          CPU years | %s
 
 ## Individual Member stats
 %s


### PR DESCRIPTION
Not all jobs from the job table have entries in job_metric_numeric. This resulted in discrepancies between the whole group stats and the sum of individual member stats. Hopefully, this PR fixes it. If none of the jobs of a user have job metrics then it is set to `0` instead of `NULL`.