### PR TITLE
Add summary and limit options to tool-metrics query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added:
 	- query queue-detail-drm, from @cat-bro and @slugger70, a better version of queue-details potentially.
+- Updated:
+	- Add summary and limit options to tool-metrics query, by @natefoo.
 
 # 20
 

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1242,6 +1242,7 @@ query_tool-metrics() { ##? <tool_id> <metric_id> [last|-1] [--like] [--ok] [--su
 		Use the --summary option to output summary statistics instead of the values themselves.
 	EOF
 
+	limit_clause=
 	summary='*'
 
 	tool_subquery="SELECT id FROM job WHERE tool_id = '$arg_tool_id'"
@@ -1252,7 +1253,7 @@ query_tool-metrics() { ##? <tool_id> <metric_id> [last|-1] [--like] [--ok] [--su
 		tool_subquery="$tool_subquery AND state = 'ok'"
 	fi
 	if [[ "$arg_last" -gt 0 ]]; then
-		tool_subquery="$tool_subquery ORDER BY id DESC LIMIT $arg_last"
+		limit_clause="ORDER BY id DESC LIMIT $arg_last"
 	fi
 	if [[ -n "$arg_summary" ]]; then
 		summary="$(summary_statistics metric_value 0)"
@@ -1269,6 +1270,7 @@ query_tool-metrics() { ##? <tool_id> <metric_id> [last|-1] [--like] [--ok] [--su
 				job_id in (
 					$tool_subquery
 				)
+			$limit_clause
 		)
 
 		SELECT


### PR DESCRIPTION
My plan is to use this to decide which jobs can run on my "fast scheduling" or "priority" destinations vs. long running/slow jobs that can wait a while if needed.

Actually returning `last` results would be nice but I don't know of a way to do this without having to return all job IDs in the subquery, ~~which is probably inefficient (although maybe PostgreSQL is smart enough here, a query plan analysis would be good I guess).~~ it's fine