### PR TITLE
Replace non-integers before casting to integer in get_user_filter

### DIFF
--- a/parts/03-query-utils.sh
+++ b/parts/03-query-utils.sh
@@ -144,6 +144,6 @@ summary_statistics() {
 	EOF
 }
 
-get_user_filter(){
-	echo "(galaxy_user.email = '$1' or galaxy_user.username = '$1' or galaxy_user.id = CAST('$1' AS INTEGER))"
+get_user_filter() {
+	echo "(galaxy_user.email = '$1' or galaxy_user.username = '$1' or galaxy_user.id = CAST(REGEXP_REPLACE('$1', '.*\D+.*', '-1') AS INTEGER))"
 }


### PR DESCRIPTION
I think this filter was working before we upgraded to postgresql 12.  Since then it has only been working for user IDs and there is an error if we try to user usename or email in queries:

```
cat@dev:~$ gxadmin query jobs-per-user cat
ERROR:  invalid input syntax for type integer: "cat"
LINE 6: ...xy_user.username = 'cat' or galaxy_user.id = CAST('cat' AS I...
```

This PR is adding a REGEXP_REPLACE so that anything that cannot be cast to integer will be replaced with '-1' before the cast.