### PR TITLE
General job query with filters

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -4305,8 +4305,8 @@ query_jobs() { ##? [--tool=] [--destination=] [--limit=] [--states=] [--user=] [
 		     14588 | 2022-10-19 10:45:42 | 2022-10-19 10:46:01 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14588
 		     14584 | 2022-10-19 10:45:12 | 2022-10-19 10:45:31 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14584
 		     14580 | 2022-10-19 10:44:43 | 2022-10-19 10:45:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14580
-		    	
-		    $ gxadmin query jobs -d=pulsar-nci-test -t=bionano
+		    
+		    $ gxadmin query jobs --destination=pulsar-nci-test --tool=bionano
 		      id   |     create_time     |     update_time     | user_id | state |                                        tool_id                                         |       handler       |         destination         | external_id
 		    -------+---------------------+---------------------+---------+-------+----------------------------------------------------------------------------------------+---------------------+-----------------------------+-------------
 		     14085 | 2022-09-08 07:44:48 | 2022-09-08 08:21:58 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14085
@@ -4322,24 +4322,14 @@ query_jobs() { ##? [--tool=] [--destination=] [--limit=] [--states=] [--user=] [
 		for args in "$@"; do
 			if [ "${args:0:7}" = '--tool=' ]; then
 				tool_id_substr="${args:7}"
-			elif [ "${args:0:3}" = '-t=' ]; then
-				tool_id_substr="${args:3}"
 			elif [ "${args:0:8}" = '--limit=' ]; then
 				limit="${args:8}"
-			elif [ "${args:0:3}" = '-l=' ]; then
-				limit="${args:3}"
 			elif [ "${args:0:14}" = '--destination=' ]; then
 				destination_id_substr="${args:14}"
-			elif [ "${args:0:3}" = '-d=' ]; then
-				destination_id_substr="${args:3}"
 			elif [ "${args:0:9}" = '--states=' ]; then
 				states="${args:9}"
-			elif [ "${args:0:3}" = '-s=' ]; then
-				states="${args:3}"
 			elif [ "${args:0:7}" = '--user=' ]; then
 				user_filter=" AND $(get_user_filter ${args:7})"
-			elif [ "${args:0:3}" = '-u=' ]; then
-				user_filter=" AND $(get_user_filter ${args:3})"
 			elif [ "${args:0:10}" = '--terminal' ]; then
 				states="ok,deleted,error"
 			elif [ "${args:0:13}" = '--nonterminal' ]; then

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -4291,3 +4291,92 @@ query_queue-details-drm() { ##? [--all] [--seconds] [--since-update]: Detailed o
 			job_data
 	EOF
 }
+
+query_jobs() { ##? [--tool|-t] [--destination|d] [--limit|-l] [--states|-s] [--user|-u] [--terminal] [--nonterminal]: List jobs ordered by most recently updated
+	handle_help "$@" <<-EOF
+		Displays a list of jobs ordered from most recently updated, which can be filtered by states, destination_id,
+		tool_id or user. By default up to 50 rows are returned which can be adjusted with the --limit or -l flag.
+
+		$ gxadmin query jobs --destination=pulsar-nci-test
+		  id   |     create_time     |     update_time     | user_id |  state  |                                           tool_id                                           |  handler  |         destination         | external_id
+		-------+---------------------+---------------------+---------+---------+---------------------------------------------------------------------------------------------+-----------+-----------------------------+-------------
+		 14701 | 2022-10-31 00:54:43 | 2022-10-31 00:55:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_0 | pulsar-nci-test             | 14701
+		 14700 | 2022-10-31 00:53:45 | 2022-10-31 00:54:04 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71                                     | handler_0 | pulsar-nci-test             | 14700
+		 14588 | 2022-10-19 10:45:42 | 2022-10-19 10:46:01 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14588
+		 14584 | 2022-10-19 10:45:12 | 2022-10-19 10:45:31 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14584
+		 14580 | 2022-10-19 10:44:43 | 2022-10-19 10:45:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14580
+			
+		$ gxadmin query jobs -d=pulsar-nci-test -t=bionano
+		  id   |     create_time     |     update_time     | user_id | state |                                        tool_id                                         |       handler       |         destination         | external_id
+		-------+---------------------+---------------------+---------+-------+----------------------------------------------------------------------------------------+---------------------+-----------------------------+-------------
+		 14085 | 2022-09-08 07:44:48 | 2022-09-08 08:21:58 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14085
+		 14080 | 2022-09-08 07:00:14 | 2022-09-08 07:44:31 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_0           | pulsar-nci-test             | 14080
+		 14076 | 2022-09-08 06:15:37 | 2022-09-08 06:59:59 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14076
+		 14071 | 2022-09-08 05:38:25 | 2022-09-08 06:15:22 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_1           | pulsar-nci-test             | 14071
+	EOF
+
+	tool_id_substr=''
+	limit=50
+			
+	if (( $# > 0 )); then
+		for args in "$@"; do
+			if [ "${args:0:7}" = '--tool=' ]; then
+				tool_id_substr="${args:7}"
+			elif [ "${args:0:3}" = '-t=' ]; then
+				tool_id_substr="${args:3}"
+			elif [ "${args:0:8}" = '--limit=' ]; then
+				limit="${args:8}"
+			elif [ "${args:0:3}" = '-l=' ]; then
+				limit="${args:3}"
+			elif [ "${args:0:14}" = '--destination=' ]; then
+				destination_id_substr="${args:14}"
+			elif [ "${args:0:3}" = '-d=' ]; then
+				destination_id_substr="${args:3}"
+			elif [ "${args:0:9}" = '--states=' ]; then
+				states="${args:9}"
+			elif [ "${args:0:3}" = '-s=' ]; then
+				states="${args:3}"
+			elif [ "${args:0:7}" = '--user=' ]; then
+				user_filter=" AND $(get_user_filter ${args:7})"
+			elif [ "${args:0:3}" = '-u=' ]; then
+				user_filter=" AND $(get_user_filter ${args:3})"
+			elif [ "${args:0:10}" = '--terminal' ]; then
+				states="ok,deleted,error"
+			elif [ "${args:0:13}" = '--nonterminal' ]; then
+				states="new,queued,running"
+			fi
+		done
+	fi
+
+	get_state_filter() {
+		if [ "$states" ]; then
+			states="'$(echo "$states" | sed "s/,/', '/g")'"
+			echo "AND job.state IN (${states})"
+		fi
+	}
+
+	get_destination_filter() {
+		if [ ! -z "$destination_id_substr" ]; then
+			echo "AND job.destination_id ~ '${destination_id_substr}'";
+		fi
+	}
+
+	read -r -d '' QUERY <<-EOF
+			SELECT
+				job.id as job_id,
+				job.create_time::timestamp(0) as create_time,
+				job.update_time::timestamp(0) as update_time,
+				job.user_id as user_id,
+				job.state as state,
+				job.tool_id as tool_id,
+				job.handler as handler,
+				job.destination_id as destination,
+				job.job_runner_external_id as external_id
+			FROM job
+			LEFT OUTER JOIN
+				galaxy_user ON job.user_id = galaxy_user.id
+			WHERE job.tool_id ~ '$tool_id_substr' $(get_destination_filter) $(get_state_filter) $user_filter
+			ORDER BY job.update_time desc
+			LIMIT $limit
+	EOF
+}

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -4338,18 +4338,16 @@ query_jobs() { ##? [--tool=] [--destination=] [--limit=] [--states=] [--user=] [
 		done
 	fi
 
-	get_state_filter() {
-		if [ "$states" ]; then
-			states="'$(echo "$states" | sed "s/,/', '/g")'"
-			echo "AND job.state IN (${states})"
-		fi
-	}
+	state_filter=
+	if [ "$states" ]; then
+		states="'$(echo "$states" | sed "s/,/', '/g")'"
+		state_filter="AND job.state IN (${states})"
+	fi
 
-	get_destination_filter() {
-		if [ ! -z "$destination_id_substr" ]; then
-			echo "AND job.destination_id ~ '${destination_id_substr}'";
-		fi
-	}
+	destination_filter=
+	if [ ! -z "$destination_id_substr" ]; then
+		destination_filter="AND job.destination_id ~ '${destination_id_substr}'";
+	fi
 
 	read -r -d '' QUERY <<-EOF
 			SELECT
@@ -4365,7 +4363,7 @@ query_jobs() { ##? [--tool=] [--destination=] [--limit=] [--states=] [--user=] [
 			FROM job
 			LEFT OUTER JOIN
 				galaxy_user ON job.user_id = galaxy_user.id
-			WHERE job.tool_id ~ '$tool_id_substr' $(get_destination_filter) $(get_state_filter) $user_filter
+			WHERE job.tool_id ~ '$tool_id_substr' ${destination_filter} ${get_state_filter} $user_filter
 			ORDER BY job.update_time desc
 			LIMIT $limit
 	EOF

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -4292,27 +4292,27 @@ query_queue-details-drm() { ##? [--all] [--seconds] [--since-update]: Detailed o
 	EOF
 }
 
-query_jobs() { ##? [--tool|-t] [--destination|d] [--limit|-l] [--states|-s] [--user|-u] [--terminal] [--nonterminal]: List jobs ordered by most recently updated
+query_jobs() { ##? [--tool=] [--destination=] [--limit=] [--states=] [--user=] [--terminal] [--nonterminal]: List jobs ordered by most recently updated. = is required.
 	handle_help "$@" <<-EOF
 		Displays a list of jobs ordered from most recently updated, which can be filtered by states, destination_id,
 		tool_id or user. By default up to 50 rows are returned which can be adjusted with the --limit or -l flag.
 
-		$ gxadmin query jobs --destination=pulsar-nci-test
-		  id   |     create_time     |     update_time     | user_id |  state  |                                           tool_id                                           |  handler  |         destination         | external_id
-		-------+---------------------+---------------------+---------+---------+---------------------------------------------------------------------------------------------+-----------+-----------------------------+-------------
-		 14701 | 2022-10-31 00:54:43 | 2022-10-31 00:55:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_0 | pulsar-nci-test             | 14701
-		 14700 | 2022-10-31 00:53:45 | 2022-10-31 00:54:04 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71                                     | handler_0 | pulsar-nci-test             | 14700
-		 14588 | 2022-10-19 10:45:42 | 2022-10-19 10:46:01 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14588
-		 14584 | 2022-10-19 10:45:12 | 2022-10-19 10:45:31 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14584
-		 14580 | 2022-10-19 10:44:43 | 2022-10-19 10:45:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14580
-			
-		$ gxadmin query jobs -d=pulsar-nci-test -t=bionano
-		  id   |     create_time     |     update_time     | user_id | state |                                        tool_id                                         |       handler       |         destination         | external_id
-		-------+---------------------+---------------------+---------+-------+----------------------------------------------------------------------------------------+---------------------+-----------------------------+-------------
-		 14085 | 2022-09-08 07:44:48 | 2022-09-08 08:21:58 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14085
-		 14080 | 2022-09-08 07:00:14 | 2022-09-08 07:44:31 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_0           | pulsar-nci-test             | 14080
-		 14076 | 2022-09-08 06:15:37 | 2022-09-08 06:59:59 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14076
-		 14071 | 2022-09-08 05:38:25 | 2022-09-08 06:15:22 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_1           | pulsar-nci-test             | 14071
+		    $ gxadmin query jobs --destination=pulsar-nci-test
+		      id   |     create_time     |     update_time     | user_id |  state  |                                           tool_id                                           |  handler  |         destination         | external_id
+		    -------+---------------------+---------------------+---------+---------+---------------------------------------------------------------------------------------------+-----------+-----------------------------+-------------
+		     14701 | 2022-10-31 00:54:43 | 2022-10-31 00:55:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_0 | pulsar-nci-test             | 14701
+		     14700 | 2022-10-31 00:53:45 | 2022-10-31 00:54:04 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71                                     | handler_0 | pulsar-nci-test             | 14700
+		     14588 | 2022-10-19 10:45:42 | 2022-10-19 10:46:01 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14588
+		     14584 | 2022-10-19 10:45:12 | 2022-10-19 10:45:31 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14584
+		     14580 | 2022-10-19 10:44:43 | 2022-10-19 10:45:02 |      16 | ok      | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2                                   | handler_2 | pulsar-nci-test             | 14580
+		    	
+		    $ gxadmin query jobs -d=pulsar-nci-test -t=bionano
+		      id   |     create_time     |     update_time     | user_id | state |                                        tool_id                                         |       handler       |         destination         | external_id
+		    -------+---------------------+---------------------+---------+-------+----------------------------------------------------------------------------------------+---------------------+-----------------------------+-------------
+		     14085 | 2022-09-08 07:44:48 | 2022-09-08 08:21:58 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14085
+		     14080 | 2022-09-08 07:00:14 | 2022-09-08 07:44:31 |       3 | ok    | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_0           | pulsar-nci-test             | 14080
+		     14076 | 2022-09-08 06:15:37 | 2022-09-08 06:59:59 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_2           | pulsar-nci-test             | 14076
+		     14071 | 2022-09-08 05:38:25 | 2022-09-08 06:15:22 |       3 | error | toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.6.1+galaxy3 | handler_1           | pulsar-nci-test             | 14071
 	EOF
 
 	tool_id_substr=''


### PR DESCRIPTION
Add a query `gxadmin query jobs` which will display the 50 most recently updated job if not given any arguments.

Arguments available are `--destination` or `-d`, `--states` or `-s`, `--tool` or `-t` and `--user` or `-u`.  The argument parsing is copied from query_jobs-nonterminal so I've added `--terminal` and `--non-terminal` filters to this.

My most frequent use cases have been to check how jobs are performing at a destination, or as a general check after a config change that jobs are mostly ending up in ok state.
