### PR TITLE
Add server command for oidc user history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 	- query potentially-duplicated-datasets, finds duplicate datasets @hexylena
 	- query potentially-duplicated-reclaimable-space, finds the potential reclaimable space, @hexylena
 	- CGI mode, use sudo fcgiwrap -s unix:/run/cgi.sock -f -p pwd/gxadmin to activate, wrap in nginx, @hexylena
-	- server oidc command to get history of OIDC user creations, thanks @abretaud
+	- server users-with-oidc command to get history of OIDC user creations, thanks @abretaud
+	- server disk-usage command to get history of disk usage, thanks @abretaud
 - Updated:
 	- Add summary and limit options to tool-metrics query, by @natefoo.
 	- Updated the Wonderful Argument Parser with a fancier version, @hexylena

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 	- query potentially-duplicated-datasets, finds duplicate datasets @hexylena
 	- query potentially-duplicated-reclaimable-space, finds the potential reclaimable space, @hexylena
 	- CGI mode, use sudo fcgiwrap -s unix:/run/cgi.sock -f -p pwd/gxadmin to activate, wrap in nginx, @hexylena
+	- server oidc command to get history of OIDC user creations
 - Updated:
 	- Add summary and limit options to tool-metrics query, by @natefoo.
 	- Updated the Wonderful Argument Parser with a fancier version, @hexylena

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 	- query potentially-duplicated-datasets, finds duplicate datasets @hexylena
 	- query potentially-duplicated-reclaimable-space, finds the potential reclaimable space, @hexylena
 	- CGI mode, use sudo fcgiwrap -s unix:/run/cgi.sock -f -p pwd/gxadmin to activate, wrap in nginx, @hexylena
-	- server oidc command to get history of OIDC user creations
+	- server oidc command to get history of OIDC user creations, thanks @abretaud
 - Updated:
 	- Add summary and limit options to tool-metrics query, by @natefoo.
 	- Updated the Wonderful Argument Parser with a fancier version, @hexylena

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -52,8 +52,8 @@ server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users log
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', galaxy_user.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -z "$arg_date" ]] then
+		date_filter="WHERE date_trunc('day', galaxy_user.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=1"

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -38,7 +38,7 @@ server_users() { ## : Count of different classifications of users
 	EOF
 }
 
-server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users logged in with OIDC
+server_oidc() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : How many users logged in with OIDC
 	meta <<-EOF
 		ADDED: 21
 		AUTHORS: abretaud
@@ -46,13 +46,13 @@ server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users log
 	handle_help "$@" <<-EOF
 	EOF
 
-	op="="
-	if [[ -z "$arg_op" ]]; then
+	op="<="
+	if [[ -n "$arg_op" ]]; then
 		op="$arg_op"
 	fi
 
 	date_filter=""
-	if [[ -z "$arg_date" ]]; then
+	if [[ -n "$arg_date" ]]; then
 		date_filter="WHERE date_trunc('day', galaxy_user.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -52,7 +52,7 @@ server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users log
 	fi
 
 	date_filter=""
-	if [[ -z "$arg_date" ]] then
+	if [[ -z "$arg_date" ]]; then
 		date_filter="WHERE date_trunc('day', galaxy_user.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -38,6 +38,38 @@ server_users() { ## : Count of different classifications of users
 	EOF
 }
 
+server_oidc() { ## : How many users logged in with OIDC
+	meta <<-EOF
+		ADDED: 22
+	EOF
+	handle_help "$@" <<-EOF
+	EOF
+
+	op="="
+	if (( $# > 1 )); then
+		op="$2"
+	fi
+
+	date_filter=""
+	if (( $# > 0 )); then
+		date_filter="WHERE date_trunc('day', galaxy_user.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	fi
+
+	fields="count=1"
+	tags="provider=0"
+
+	read -r -d '' QUERY <<-EOF
+		SELECT
+			provider, count(distinct user_id)
+		FROM
+			oidc_user_authnz_tokens
+			JOIN
+				galaxy_user ON oidc_user_authnz_tokens.user_id = galaxy_user.id
+		$date_filter
+		GROUP BY provider
+	EOF
+}
+
 server_groups() { ## : Counts of group memberships
 	meta <<-EOF
 		ADDED: 12

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -38,7 +38,7 @@ server_users() { ## : Count of different classifications of users
 	EOF
 }
 
-server_oidc() { ## : How many users logged in with OIDC
+server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users logged in with OIDC
 	meta <<-EOF
 		ADDED: 21
 		AUTHORS: abretaud

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -6,8 +6,7 @@ _server_long_help="
 	In all cases 'explainquery' will show you the query plan, in case you need to optimise or index data. 'explainjsonquery' is useful with PEV: http://tatiyants.com/pev/
 "
 
-
-server_users() { ## : Count of different classifications of users
+server_users() { ##? [--op=<...>] [--date=<yyyy-mm-dd>]: Count of different classifications of users
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -15,13 +14,13 @@ server_users() { ## : Count of different classifications of users
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=4"
@@ -71,7 +70,7 @@ server_users-with-oidc() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : How many use
 	EOF
 }
 
-server_groups() { ## : Counts of group memberships
+server_groups() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of group memberships
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -79,13 +78,13 @@ server_groups() { ## : Counts of group memberships
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND galaxy_group.create_time AT TIME ZONE 'UTC' <= '$1'::date AND date_trunc('day', user_group_association.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND galaxy_group.create_time AT TIME ZONE 'UTC' <= '$arg_date'::date AND date_trunc('day', user_group_association.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 
@@ -104,7 +103,7 @@ server_groups() { ## : Counts of group memberships
 	EOF
 }
 
-server_datasets() { ## : Counts of datasets
+server_datasets() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of datasets
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -112,13 +111,13 @@ server_datasets() { ## : Counts of datasets
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=4;size=5"
@@ -140,7 +139,7 @@ server_datasets() { ## : Counts of datasets
 	EOF
 }
 
-server_hda() { ## : Counts of HDAs
+server_hda() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of HDAs
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -148,13 +147,13 @@ server_hda() { ## : Counts of HDAs
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', history_dataset_association.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', history_dataset_association.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="sum=2;avg=3;min=4;max=5;count=6"
@@ -179,7 +178,7 @@ server_hda() { ## : Counts of HDAs
 	EOF
 }
 
-server_ts-repos() { ## : Counts of TS repos
+server_ts-repos() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of TS repos
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -187,13 +186,13 @@ server_ts-repos() { ## : Counts of TS repos
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=2"
@@ -211,7 +210,7 @@ server_ts-repos() { ## : Counts of TS repos
 	EOF
 }
 
-server_histories() { ## : Counts of histories and sharing
+server_histories() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of histories and sharing
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -219,13 +218,13 @@ server_histories() { ## : Counts of histories and sharing
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=6"
@@ -242,7 +241,7 @@ server_histories() { ## : Counts of histories and sharing
 }
 
 
-server_jobs() { ## : Counts of jobs
+server_jobs() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of jobs
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -250,13 +249,13 @@ server_jobs() { ## : Counts of jobs
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=3"
@@ -275,7 +274,7 @@ server_jobs() { ## : Counts of jobs
 	EOF
 }
 
-server_allocated-cpu() { ## : CPU time per job runner
+server_allocated-cpu() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : CPU time per job runner
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -283,13 +282,13 @@ server_allocated-cpu() { ## : CPU time per job runner
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	# TODO: here we select the hostname, don't do that.
@@ -318,7 +317,7 @@ server_allocated-cpu() { ## : CPU time per job runner
 	EOF
 }
 
-server_allocated-gpu() { ## : GPU time per job runner
+server_allocated-gpu() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : GPU time per job runner
 	meta <<-EOF
 		ADDED: 14
 	EOF
@@ -326,13 +325,13 @@ server_allocated-gpu() { ## : GPU time per job runner
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="gpu_seconds=1"
@@ -357,7 +356,7 @@ server_allocated-gpu() { ## : GPU time per job runner
 	EOF
 }
 
-server_workflows() { ## : Counts of workflows
+server_workflows() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of workflows
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -365,13 +364,13 @@ server_workflows() { ## : Counts of workflows
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=3"
@@ -388,7 +387,7 @@ server_workflows() { ## : Counts of workflows
 	EOF
 }
 
-server_workflow-invocations() { ## : Counts of workflow invocations
+server_workflow-invocations() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Counts of workflow invocations
 	meta <<-EOF
 		ADDED: 12
 	EOF
@@ -396,13 +395,13 @@ server_workflow-invocations() { ## : Counts of workflow invocations
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="WHERE date_trunc('day', create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	fields="count=2"
@@ -421,7 +420,7 @@ server_workflow-invocations() { ## : Counts of workflow invocations
 	EOF
 }
 
-server_groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the disk usage for groups
+server_groups-disk-usage() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Retrieve an approximation of the disk usage for groups
 	meta <<-EOF
 		ADDED: 14
 	EOF
@@ -429,13 +428,13 @@ server_groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an 
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', dataset.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', dataset.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')
@@ -461,7 +460,7 @@ server_groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an 
 	EOF
 }
 
-server_groups-allocated-cpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the CPU allocation for groups
+server_groups-allocated-cpu() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Retrieve an approximation of the CPU allocation for groups
 	meta <<-EOF
 		ADDED: 14
 	EOF
@@ -469,13 +468,13 @@ server_groups-allocated-cpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve 
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')
@@ -514,7 +513,7 @@ server_groups-allocated-cpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve 
 	EOF
 }
 
-server_groups-allocated-gpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the GPU allocation for groups
+server_groups-allocated-gpu() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : Retrieve an approximation of the GPU allocation for groups
 	meta <<-EOF
 		ADDED: 14
 	EOF
@@ -522,13 +521,13 @@ server_groups-allocated-gpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve 
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -n "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""
-	if (( $# > 0 )); then
-		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	if [[ -n "$arg_date" ]]; then
+		date_filter="AND date_trunc('day', job.create_time AT TIME ZONE 'UTC') $op '$arg_date'::date"
 	fi
 
 	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -38,7 +38,7 @@ server_users() { ## : Count of different classifications of users
 	EOF
 }
 
-server_oidc() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : How many users logged in with OIDC
+server_users-with-oidc() { ##? [--op=<...>] [--date=<yyyy-mm-dd>] : How many users logged in with OIDC
 	meta <<-EOF
 		ADDED: 21
 		AUTHORS: abretaud

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -40,7 +40,7 @@ server_users() { ## : Count of different classifications of users
 
 server_oidc() { ## : How many users logged in with OIDC
 	meta <<-EOF
-		ADDED: 22
+		ADDED: 21
 	EOF
 	handle_help "$@" <<-EOF
 	EOF

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -41,6 +41,7 @@ server_users() { ## : Count of different classifications of users
 server_oidc() { ## : How many users logged in with OIDC
 	meta <<-EOF
 		ADDED: 21
+		AUTHORS: abretaud
 	EOF
 	handle_help "$@" <<-EOF
 	EOF

--- a/parts/29-server.sh
+++ b/parts/29-server.sh
@@ -47,8 +47,8 @@ server_oidc() { ##? [--op=<=,!=,...>] [--date=<yyyy-mm-dd>] : How many users log
 	EOF
 
 	op="="
-	if (( $# > 1 )); then
-		op="$2"
+	if [[ -z "$arg_op" ]]; then
+		op="$arg_op"
 	fi
 
 	date_filter=""


### PR DESCRIPTION
Adding a server command to fill our influxdb with the evolution of the number of OIDC accounts since the opening of the server.

Strangely, I tried to name the function `server_users-with-oidc`, but it ran `server_users` at the same time, not sure if it's intended.