### PR TITLE
Add `mutate scale-table-autovacuum` for dynamically setting autovacuum and autoanalyze on larger tables based on table size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 22-pre
 
 - Added:
-    - filter histogram: replaces bit.ly's data_hacks with a built-in AWK program to calculate a histogram. May not be entirely portable @hexylena.
+	- filter histogram: replaces bit.ly's data_hacks with a built-in AWK program to calculate a histogram. May not be entirely portable @hexylena.
+	- mutate scale-table-autovacuum: Dynamically update autovacuum and autoanalyze scale for large tables. @natefoo
 - Fixed:
 	- Replaced hardcoded metric_name with the variable in query_tool-metrics function @sanjaysrikakulam
 


### PR DESCRIPTION
See https://www.enterprisedb.com/blog/postgresql-vacuum-and-analyze-best-practice-tips for discussion on why you might want to do this.