### PR TITLE
Add mutate queries to fix missing usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 	- filter histogram: replaces bit.ly's data_hacks with a built-in AWK program to calculate a histogram. May not be entirely portable @hexylena.
 	- mutate scale-table-autovacuum: Dynamically update autovacuum and autoanalyze scale for large tables. @natefoo
 	- query tools-usage-per-month from @lldelisle
+	- mutate derive-missing-username-from-email and mutate set-missing-username-to-random-uuid from @mvdbeek
 - Updated:
 	- query monthly-cpu-stats to add --nb_users --filter_email by @lldelisle
 - Fixed:

--- a/parts/21-mutate.sh
+++ b/parts/21-mutate.sh
@@ -1606,9 +1606,10 @@ mutate_purge-old-job-metrics() { ##? [--commit]: Purge job metrics older than 1 
 	QUERY="$txn_pre $QUERY; $txn_pos"
 }
 
-mutate_derive_missing_username_from_email() { ##? [--commit]: Set empty username to email address for users created before 2011
+mutate_derive-missing-username-from-email() { ##? [--commit]: Set empty username to email address for users created before 2011
 	meta <<-EOF
 		ADDED: 22
+		AUTHORS: mvdbeek
 	EOF
 	handle_help "$@" <<-EOF
 		Galaxy did not require setting a username for users registered prior to 2011.
@@ -1617,7 +1618,7 @@ mutate_derive_missing_username_from_email() { ##? [--commit]: Set empty username
 		will be set to "jane.doe" if the the user did not have a username and no other user
 		has been registered with that username.
 		It is recommended that usernames that could not be changed due to conflicts are fixed
-		using mutate_set_missing_username_to_random_uuid()
+		using mutate set-missing-username-to-random-uuid()
 	EOF
 
 	read -r -d '' QUERY <<-EOF
@@ -1644,9 +1645,10 @@ mutate_derive_missing_username_from_email() { ##? [--commit]: Set empty username
 	QUERY="$txn_pre $QUERY; $txn_pos"
 }
 
-mutate_set_missing_username_to_random_uuid() { ##? [--commit]: Set empty username to random uuid
+mutate_set-missing-username-to-random-uuid() { ##? [--commit]: Set empty username to random uuid
 	meta <<-EOF
 		ADDED: 22
+		AUTHORS: mvdbeek
 	EOF
 	handle_help "$@" <<-EOF
 		Galaxy did not require setting a username for users registered prior to 2011.

--- a/test.sh
+++ b/test.sh
@@ -82,3 +82,11 @@ GXADMIN=./.tmpgxadmin
 	fi
 	[ "$result" -eq 0 ]
 }
+
+@test "Ensure query names are standardised and match [type]_q-u-e-r-y" {
+	result=$(grep -P '^[a-z]+_[a-z-]*_[a-z-_]*\(\)' ${GXADMIN} -c)
+	if (( result > 20 )); then
+		grep -P '^[a-z]+_[a-z-]*_[a-z-_]*\(\)' parts/2*
+	fi
+	[ "$result" -eq 20 ]
+}


### PR DESCRIPTION
Either by setting the username to the lowercase first portion of the email address (which excludes any conflicts), or by setting the username to a uuid (you can use this for confictls).