### PR TITLE
Order 'query job-history' by time

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -2536,6 +2536,7 @@ query_job-history() { ##? <id>: Job state history for a specific job
 				state
 			FROM job_state_history
 			WHERE job_id = $arg_id
+   			ORDER BY create_time ASC
 	EOF
 }
 


### PR DESCRIPTION
order the events returned by 'gxadmin query job-history X' by time - they can often listed out of order.