### PR TITLE
update tool-use-by-group query

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1174,8 +1174,8 @@ EOFhelp
 			user_group_association.user_id = galaxy_user.id
 		AND
 			date_trunc('month', job.create_time) = '$arg_year_month-01'
-   		AND
-     			galaxy_group.name = '$arg_group'
+		AND
+			galaxy_group.name = '$arg_group'
 		GROUP BY
 			job.tool_id, galaxy_user.username
 EOF

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1174,6 +1174,8 @@ EOFhelp
 			user_group_association.user_id = galaxy_user.id
 		AND
 			date_trunc('month', job.create_time) = '$arg_year_month-01'
+   		AND
+     			galaxy_group.name = '$arg_group'
 		GROUP BY
 			job.tool_id, galaxy_user.username
 EOF

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1140,7 +1140,7 @@ query_tool-last-used-date() { ## : When was the most recent invocation of every 
 	EOF
 }
 
-query_tool-use-by-group() { ##? <years_month> [--group=<name>]: Lists count of tools used by all users in a group
+query_tool-use-by-group() { ##? <year_month> [--group=<name>]: Lists count of tools used by all users in a group
 	meta <<-EOF
 		ADDED: 19
 	EOF

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1140,7 +1140,7 @@ query_tool-last-used-date() { ## : When was the most recent invocation of every 
 	EOF
 }
 
-query_tool-use-by-group() { ##? <year_month> [--group=<name>]: Lists count of tools used by all users in a group
+query_tool-use-by-group() { ##? <year_month> <group>: Lists count of tools used by all users in a group
 	meta <<-EOF
 		ADDED: 19
 		UPDATED: 22

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1143,6 +1143,8 @@ query_tool-last-used-date() { ## : When was the most recent invocation of every 
 query_tool-use-by-group() { ##? <year_month> [--group=<name>]: Lists count of tools used by all users in a group
 	meta <<-EOF
 		ADDED: 19
+		UPDATED: 22
+		AUTHORS: gavindi
 	EOF
 	handle_help "$@" <<-EOFhelp
 		Lists tools use count by users in group.


### PR DESCRIPTION
This fails with a syntax error
```
cat@galaxy:~$ gxadmin query tool-use-by-group 2022-02-01 --group=QUT_users
ERROR:  invalid input syntax for type timestamp: "-01"
LINE 12: date_trunc('month', job.create_time) = '-01'
```

This looks like a typo with year_month vs years_month
