### PR TITLE
Use days as interval in `query archivable-histories` rather than minutes.

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -5256,8 +5256,8 @@ query_archivable-histories() { ##? [--user-last-active=360] [--history-last-acti
 			AND NOT history.purged
 			AND NOT history_dataset_association.deleted
 			AND NOT history_dataset_association.purged
-			AND history.update_time < now() - interval '$arg_history_last_active minutes'
-			AND galaxy_user.update_time < now() - interval '$arg_user_last_active minutes'
+			AND history.update_time < now() - interval '$arg_history_last_active days'
+			AND galaxy_user.update_time < now() - interval '$arg_user_last_active days'
 			$extra_conds
 		GROUP BY
 			history.id, galaxy_user.id


### PR DESCRIPTION
I have no idea how this happened, very strange. I must've been testing something and didn't notice it when I went to commit when making the last PR changing this query.