### PR TITLE
Add extensions in query_tool-memory-per-inputs

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1622,6 +1622,7 @@ query_tool-memory-per-inputs() { ##? <tool_id> [--like]: See memory usage and in
 				count(jtid.id) AS input_count,
 				sum(d.total_size) AS total_input_size,
 				avg(d.total_size) AS mean_input_size,
+				string_agg(DISTINCT hda.extension, ',' ORDER BY hda.extension) AS extensions,
 				percentile_cont(0.5) WITHIN GROUP (ORDER BY d.total_size) AS median_input_size
 			FROM
 				job_cte j
@@ -1643,7 +1644,8 @@ query_tool-memory-per-inputs() { ##? <tool_id> [--like]: See memory usage and in
 			(m.memory_used/1024/1024)::bigint AS memory_used_mb,
 			(m.memory_used/NULLIF(d.total_input_size,0))::bigint AS memory_used_per_input_mb,
 			(m.memory_used/NULLIF(d.mean_input_size,0))::bigint AS memory_mean_input_ratio,
-			(m.memory_used/NULLIF(d.median_input_size,0))::bigint AS memory_median_input_ratio
+			(m.memory_used/NULLIF(d.median_input_size,0))::bigint AS memory_median_input_ratio,
+			d.extensions
 		FROM
 			job_cte j
 		JOIN


### PR DESCRIPTION
This should be helpful for when the regressions fail ... I bet the two clusters correlate with the input extension(s):

<img width="1483" height="882" alt="bandage_regression_plot" src="https://github.com/user-attachments/assets/de28ab90-e4f2-42b8-b263-6f23c80527b7" />
