### PR TITLE
Distinct user count per tool

### DIFF
--- a/docs/README.query.md
+++ b/docs/README.query.md
@@ -92,6 +92,8 @@ Command | Description
 [`query tools-usage-per-month`](#query-tools-usage-per-month) | By default, startmonth is 1 year ago and end month is current month. tool1, tool2 etc. should correspond to the tool_id with the same format as requested: toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.0+galaxy0,Cut1 for default, devteam/bowtie2/bowtie2/2.5.0+galaxy0,Cut1 for --short_tool_id, bowtie2/2.5.0+galaxy0,Cut1 for --super_short_tool_id etc...
 [`query tool-usage-over-time`](#query-tool-usage-over-time) | Counts of tool runs by month, filtered by a tool id search
 [`query tool-usage`](#query-tool-usage) | Counts of tool runs in the past weeks (default = all)
+[`query user-tool-usage-over-time`](#query-user-tool-usage-over-time) | Counts distinct users per tool by month for the last 5 years (default = all users)
+[`query user-tool-usage`](#query-user-tool-usage) | Counts distinct users per tool for the last 5 years (default = all users)
 [`query tool-use-by-group`](#query-tool-use-by-group) | Lists count of tools used by all users in a group
 [`query total-jobs`](#query-total-jobs) | Total number of jobs run by Galaxy instance.
 [`query tpt-tool-cpu`](#query-tpt-tool-cpu) | Start year is required. Formula returns sum if blank.
@@ -2146,6 +2148,59 @@ query tool-usage -  Counts of tool runs in the past weeks (default = all)
      Filter1                                                                |  43253
 
 
+## query user-tool-usage-over-time
+
+([*source*](https://github.com/galaxyproject/gxadmin/search?q=query_user-tool-usage-over-time&type=Code))
+query user-tool-usage-over-time -  Counts distinct users per tool by month for the last 5 years (default = all users)
+
+**SYNOPSIS**
+
+    gxadmin query user-tool-usage-over-time [user_id]
+
+**NOTES**
+
+Counts distinct users per normalized tool name by month for the last 5 years.
+By default, includes all users. Optionally pass a specific user_id.
+
+    $ gxadmin query user-tool-usage-over-time
+    $ gxadmin query user-tool-usage-over-time 12345
+
+Example:
+month       | tool_name                                                           | count
+------------+---------------------------------------------------------------------+-------
+ 2026-01-01 | __DATA_FETCH__                                                      |  5732
+ 2026-01-01 | toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc                  |  1388
+ 2026-01-01 | __SET_METADATA__                                                    |   883
+ 2026-01-01 | CONVERTER_gz_to_uncompressed                                        |   816
+ 2026-01-01 | toolshed.g2.bx.psu.edu/repos/iuc/falco/falco                        |   788
+ 2026-01-01 | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc                    |   733
+ 2026-01-01 | toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic       |   606
+ 2026-01-01 | toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts        |   565
+
+## query user-tool-usage
+
+([*source*](https://github.com/galaxyproject/gxadmin/search?q=query_user-tool-usage&type=Code))
+query user-tool-usage -  Counts distinct users per tool for the last 5 years (default = all users)
+
+**SYNOPSIS**
+
+    gxadmin query user-tool-usage [user_id]
+
+**NOTES**
+
+Counts distinct users per normalized tool name for the last 5 years.
+By default, includes all users. Optionally pass a specific user_id.
+
+    $ gxadmin query user-tool-usage
+    $ gxadmin query user-tool-usage 12345
+
+Example:
+tool_name                                                                         | count          ----------------------------------------------------------------------------------+-------                         
+__DATA_FETCH__                                                                    | 97369                          
+toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc                                | 56282
+toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc                                  | 26981                          
+CONVERTER_gz_to_uncompressed                                                      | 24327                          
+
 ## query tool-use-by-group
 
 ([*source*](https://github.com/galaxyproject/gxadmin/search?q=query_tool-use-by-group&type=Code))
@@ -2663,4 +2718,3 @@ query workflow-invocation-totals -  Report on overall workflow counts, to ensure
 **NOTES**
 
 Really only intended to be used in influx queries.
-

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -121,6 +121,86 @@ query_latest-users() { ## : 40 recently registered users
 	EOF
 }
 
+query_tool-usage() { ##? [weeks]: Counts of tool runs in the past weeks (default = all)
+	handle_help "$@" <<-EOF
+		    $ gxadmin tool-usage
+		                                    tool_id                                 | count
+		    ------------------------------------------------------------------------+--------
+		     toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0  | 958154
+		     Grouping1                                                              | 638890
+		     toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0  | 326959
+		     toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0      | 320236
+		     addValue                                                               | 313470
+		     toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0            | 312735
+		     upload1                                                                | 103595
+		     toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/nspdk_sparse/9.2 |  52861
+		     Filter1                                                                |  43253
+	EOF
+
+	where=
+	if (( arg_weeks > 0 )); then
+		where="WHERE j.create_time > (now() - '${arg_weeks} weeks'::interval)"
+	fi
+
+	fields="count=1"
+	tags="tool_id=0"
+
+	read -r -d '' QUERY <<-EOF
+		SELECT
+			j.tool_id, count(*) AS count
+		FROM job j
+		$where
+		GROUP BY j.tool_id
+		ORDER BY count DESC
+	EOF
+}
+
+query_tool-usage-over-time() { ##? [searchterm]: Counts of tool runs by month, filtered by a tool id search
+	meta <<-EOF
+		ADDED: 19
+	EOF
+	handle_help "$@" <<-EOF
+		    $ gxadmin tool-usage-over-time
+		                                    tool_id                                 | count
+		    ------------------------------------------------------------------------+--------
+		     toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0  | 958154
+		     Grouping1                                                              | 638890
+		     toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0  | 326959
+		     toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0      | 320236
+		     addValue                                                               | 313470
+		     toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0            | 312735
+		     upload1                                                                | 103595
+		     toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/nspdk_sparse/9.2 |  52861
+		     Filter1                                                                |  43253
+	EOF
+
+	where=
+	if [[ "$arg_searchterm" != "" ]]; then
+		where="WHERE tool_id like '%$arg_searchterm%'"
+	fi
+
+	read -r -d '' QUERY <<-EOF
+		WITH
+			cte
+				AS (
+					SELECT
+						date_trunc('month', create_time),
+						tool_id
+					FROM
+						job
+					$where
+				)
+		SELECT
+			date_trunc, tool_id, count(*)
+		FROM
+			cte
+		GROUP BY
+			date_trunc, tool_id
+		ORDER BY
+			date_trunc ASC, count DESC
+	EOF
+}
+
 query_user-tool-usage() { ##? [user_id]: Counts distinct users per tool for the last 5 years (default = all users)
 	handle_help "$@" <<-EOF
 		Counts distinct users per normalized tool name for the last 5 years.

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -121,83 +121,71 @@ query_latest-users() { ## : 40 recently registered users
 	EOF
 }
 
-query_tool-usage() { ##? [weeks]: Counts of tool runs in the past weeks (default = all)
+query_user-tool-usage() { ##? [user_id]: Counts distinct users per tool for the last 5 years (default = all users)
 	handle_help "$@" <<-EOF
-		    $ gxadmin tool-usage
-		                                    tool_id                                 | count
-		    ------------------------------------------------------------------------+--------
-		     toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0  | 958154
-		     Grouping1                                                              | 638890
-		     toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0  | 326959
-		     toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0      | 320236
-		     addValue                                                               | 313470
-		     toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0            | 312735
-		     upload1                                                                | 103595
-		     toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/nspdk_sparse/9.2 |  52861
-		     Filter1                                                                |  43253
+		Counts distinct users per normalized tool name for the last 5 years.
+		By default, includes all users. Optionally pass a specific user_id.
+
+		    $ gxadmin query user-tool-usage
+		    $ gxadmin query user-tool-usage 123
 	EOF
 
-	where=
-	if (( arg_weeks > 0 )); then
-		where="WHERE j.create_time > (now() - '${arg_weeks} weeks'::interval)"
+	user_filter=
+	if [[ "$arg_user_id" != "" ]]; then
+		user_filter="AND user_id = '$arg_user_id'"
 	fi
 
 	fields="count=1"
-	tags="tool_id=0"
+	tags="tool_name=0"
 
 	read -r -d '' QUERY <<-EOF
 		SELECT
-			j.tool_id, count(*) AS count
-		FROM job j
-		$where
-		GROUP BY j.tool_id
+			tool_name, COUNT(*) AS count
+		FROM (
+			SELECT DISTINCT
+				REGEXP_REPLACE(tool_id, '(.*)/(.*)', '\1') AS tool_name,
+				user_id
+			FROM job
+			WHERE create_time BETWEEN CURRENT_DATE - INTERVAL '5 years' AND CURRENT_DATE
+			$user_filter
+			GROUP BY tool_name, user_id
+		) AS subquery
+		GROUP BY tool_name
 		ORDER BY count DESC
 	EOF
 }
 
-query_tool-usage-over-time() { ##? [searchterm]: Counts of tool runs by month, filtered by a tool id search
+query_user-tool-usage-over-time() { ##? [user_id]: Counts distinct users per tool by month for the last 5 years (default = all users)
 	meta <<-EOF
 		ADDED: 19
+		UPDATED: 26
 	EOF
 	handle_help "$@" <<-EOF
-		    $ gxadmin tool-usage-over-time
-		                                    tool_id                                 | count
-		    ------------------------------------------------------------------------+--------
-		     toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0  | 958154
-		     Grouping1                                                              | 638890
-		     toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0  | 326959
-		     toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0      | 320236
-		     addValue                                                               | 313470
-		     toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0            | 312735
-		     upload1                                                                | 103595
-		     toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/nspdk_sparse/9.2 |  52861
-		     Filter1                                                                |  43253
+		Counts distinct users per normalized tool name by month for the last 5 years.
+		By default, includes all users. Optionally pass a specific user_id.
+
+		    $ gxadmin query user-tool-usage-over-time
+		    $ gxadmin query user-tool-usage-over-time 123
 	EOF
 
-	where=
-	if [[ "$arg_searchterm" != "" ]]; then
-		where="WHERE tool_id like '%$arg_searchterm%'"
+	user_filter=
+	if [[ "$arg_user_id" != "" ]]; then
+		user_filter="AND user_id = '$arg_user_id'"
 	fi
 
+	fields="count=2"
+	tags="month=0;tool_name=1"
+
 	read -r -d '' QUERY <<-EOF
-		WITH
-			cte
-				AS (
-					SELECT
-						date_trunc('month', create_time),
-						tool_id
-					FROM
-						job
-					$where
-				)
 		SELECT
-			date_trunc, tool_id, count(*)
-		FROM
-			cte
-		GROUP BY
-			date_trunc, tool_id
-		ORDER BY
-			date_trunc ASC, count DESC
+			date_trunc('month', create_time)::date AS month,
+			REGEXP_REPLACE(tool_id, '(.*)/(.*)', '\1') AS tool_name,
+			COUNT(DISTINCT user_id) AS count
+		FROM job
+		WHERE create_time BETWEEN CURRENT_DATE - INTERVAL '5 years' AND CURRENT_DATE
+		$user_filter
+		GROUP BY month, tool_name
+		ORDER BY month ASC, count DESC
 	EOF
 }
 


### PR DESCRIPTION
This pull request adds two new queries to the `gxadmin` tool for reporting on distinct user counts per tool, both overall, and over time. Part of integrating the last two queries from: 

https://github.com/galaxyproject/galaxy_codex/blob/main/sources/data/usage_stats/usage_stats_2025.08.31/README.md#tool-users-for-ever

I have tested against EU db instance and it looks good.

xref: https://github.com/usegalaxy-eu/issues/issues/510