### PR TITLE
fix an unknown column name

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -3404,7 +3404,7 @@ query_tool-new-errors() { ##? [weeks=4] [--short-tool-id]: Summarize percent of 
 					GROUP BY j.tool_id
 				)
 		GROUP BY j.tool_id, j.handler
-		ORDER BY percent_failed_errored DESC
+		ORDER BY percent_errored DESC
 	EOF
 }
 


### PR DESCRIPTION
fixes:
ERROR:  column "percent_failed_errored" does not exist LINE 19: ORDER BY percent_failed_errored DESC